### PR TITLE
Support HTTP verbs

### DIFF
--- a/lib/restful-router.js
+++ b/lib/restful-router.js
@@ -45,15 +45,21 @@ module.exports = function restfulRouter(options) {
   debug('%s => %s', name, url);
   var routes = [
     [ 'get', url, 'list' ],
+    [ 'get', url, 'index' ],
     [ 'get', url + '/new', 'new' ],
     [ 'get', url + '/:' + key, 'show' ],
+    [ 'get', url + '/:' + key, 'get' ],
     [ 'get', url + '/:' + key + '/edit', 'edit' ],
 
     [ 'post', url, 'create' ],
+    [ 'post', url, 'post' ],
     [ 'patch', url + '/:' + key, 'update' ],
+    [ 'patch', url + '/:' + key, 'patch' ],
+    [ 'put', url + '/:' + key, 'put' ],
     [ 'delete', url + '/:' + key, 'destroy' ],
+    [ 'delete', url + '/:' + key, 'delete' ],
   ];
-  
+
   for (var i = 0; i < routes.length; i++) {
     var route = routes[i];
     var handle = controller[route[2]];


### PR DESCRIPTION
Adds support for HTTP verbs as route methods without breaking existing terminology.

It makes it possible to define resources as CRUD methods, while still exporting a single Express middleware so it can be mounted anywhere.

Use-case example:

``` js
import resource from 'restful-router';
import extend from 'extend';
import uuid from 'uuid-v4';

var things = [];

export default resource({
    id : 'thing',
    load(req, id, callback) {
        var thing = things.find( ({ _id }) => _id==id );
        callback(thing?null:'Not found', thing);
    },
    index(req, { json }) {
        json(things);
    },
    post({ body }, { json }) {
        things.push( extend(body, { _id:uuid() }) );
        json(body);
    },
    get({ thing }, { status }) {
        status(thing?200:404).json(thing);
    },
    patch({ thing, body }, { json }) {
        json( extend(thing, body) );
    },
    put({ body, thing }, { json }) {
        json( things[ things.indexOf(thing) ] = extend(body, { _id:thing._id }) );
    },
    delete({ thing }, { status }) {
        things.splice(things.indexOf(thing), 1);
        status(204).end();
    }
});
```
